### PR TITLE
Add placeholder video section on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,20 @@
 
   <main class="container mx-auto px-6 py-16 sm:py-24">
 
+    <!-- Introductory Video Section -->
+    <section class="text-center mb-16">
+      <h2 class="text-3xl sm:text-4xl font-bold">A Message From Us</h2>
+      <p class="mt-3 text-lg text-gray-700 max-w-3xl mx-auto">
+        Hear how CareerSum can guide your next career move and make a broader impact.
+      </p>
+      <div class="mt-6">
+        <video controls class="w-full max-w-3xl mx-auto rounded-lg shadow-lg">
+          <source src="./assets/invite-video.mp4" type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
+      </div>
+    </section>
+
     <!-- Who We Are Section -->
     <section class="text-center max-w-4xl mx-auto">
       <h2 class="text-3xl sm:text-4xl font-bold text-blue-700">Our Philosophy</h2>


### PR DESCRIPTION
## Summary
- embed a new introductory video section after the hero on the homepage
- add placeholder `invite-video.mp4` in the assets directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688873cc7b8c8325b6545fca162345ee